### PR TITLE
Add MSFS to Simulator enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,8 @@ export enum Simulator {
   ESP,
   P3D,
   FSX64,
-  P3D64
+  P3D64,
+  MSFS,
 }
 
 export class FSUIPC {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsuipc",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Node bindings for FSUIPC",
   "keywords": [
     "fsuipc",

--- a/src/FSUIPC.cc
+++ b/src/FSUIPC.cc
@@ -495,6 +495,9 @@ NAN_MODULE_INIT(InitSimulator) {
                          Nan::New(static_cast<int>(Simulator::FSX64)), v8::ReadOnly);
   Nan::DefineOwnProperty(obj, Nan::New("P3D64").ToLocalChecked(),
                          Nan::New(static_cast<int>(Simulator::P3D64)), v8::ReadOnly);
+  Nan::DefineOwnProperty(obj, Nan::New("MSFS").ToLocalChecked(),
+                         Nan::New(static_cast<int>(Simulator::MSFS)), v8::ReadOnly);
+                         
 
   target->Set(Nan::GetCurrentContext(), Nan::New("Simulator").ToLocalChecked(),
               obj);

--- a/src/IPCUser.h
+++ b/src/IPCUser.h
@@ -78,7 +78,8 @@ enum class Simulator: int {
     ESP = 9,
     P3D = 10,
     FSX64 = 11,
-    P3D64 = 12
+    P3D64 = 12,
+    MSFS = 13
 };
 
 class IPCUser {


### PR DESCRIPTION
Adds MSFS to the simulator enum.
I tested it locally. Allows for connection to MSFS and not to connect to X-Plane 11.